### PR TITLE
fix: bg_float color is referenced before being evaluated

### DIFF
--- a/lua/eldritch/theme.lua
+++ b/lua/eldritch/theme.lua
@@ -23,7 +23,7 @@ function M.setup()
     colors = colors.setup(),
   }
   local is_transparent = theme.config.transparent
-  local transparent_bg_float = is_transparent and colors.none or colors.bg_float
+  local transparent_bg_float = is_transparent and colors.none or theme.colors.bg_float
 
   local c = theme.colors
 


### PR DESCRIPTION
See #4 .

`colors.bg_float` is used in the `theme.lua` even though this field is `nil` until dynamically evaluated during the `colors.setup()` function. The return value of `colors.setup()` should be used to access such dynamic fields.