### PR TITLE
feat: Allow selecting color scheme via vim.cmd.colorscheme and improve variant switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you want transparent background for all of fzf-lua you need to pass the follo
 require("eldritch").setup({
   -- your configuration comes here
   -- or leave it empty to use the default settings
-  palette = "default", -- Available options: "default" (standard palette), "darker" (darker variant)
+  -- palette = "default", -- This option is deprecated. Use `vim.cmd[[colorscheme eldritch-dark]]` instead.
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in [Neovim](https://github.com/neovim/neovim)
   styles = {

--- a/colors/eldritch-dark.lua
+++ b/colors/eldritch-dark.lua
@@ -1,0 +1,2 @@
+vim.g.colors_name = "eldritch-dark"
+require("eldritch").load("darker")

--- a/colors/eldritch.lua
+++ b/colors/eldritch.lua
@@ -1,1 +1,2 @@
+vim.g.colors_name = "eldritch"
 require("eldritch").load()

--- a/lua/eldritch/colors.lua
+++ b/lua/eldritch/colors.lua
@@ -77,24 +77,23 @@ M.darker = {
   git = {
     change = "#506299",
     add = "#2dcc82",
-    delete = "#cc5860"
+    delete = "#cc5860",
   },
   gitSigns = {
     add = "#2dcc82",
     change = "#506299",
-    delete = "#cc5860"
+    delete = "#cc5860",
   },
 }
 
 ---@return ColorScheme
-function M.setup(opts)
-  opts = opts or {}
+function M.setup()
   local config = require("eldritch.config")
-  local palette = config.options.palette or "default"
+  local palette_name = config.options.palette or "default"
 
   -- Color Palette
   ---@class ColorScheme: Palette
-  local colors = M[palette] or M.default
+  local colors = M[palette_name] or M.default
 
   util.bg = colors.bg
 

--- a/lua/eldritch/config.lua
+++ b/lua/eldritch/config.lua
@@ -5,7 +5,7 @@ local M = {}
 ---@field on_highlights fun(highlights: Highlights, colors: ColorScheme)
 local defaults = {
   transparent = false, -- Enable this to disable setting the background color
-  palette = "default", -- Choose between 'default' or 'darker' mode
+  palette = "default", -- DEPRECATED: Use `vim.cmd.colorscheme eldritch-dark` instead to switch to the darker palette.
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {
     -- Style to be applied to different syntax groups
@@ -41,17 +41,27 @@ local defaults = {
 
 ---@type Config
 M.options = {}
+-- NOTE: This is temprorary for retrocompatibility with palette option
+M.initial_options = {} -- To store options from eldritch.setup()
 
 ---@param options Config|nil
 function M.setup(options)
   M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
+  M.initial_options = M.options
 end
 
 ---@param options Config|nil
 function M.extend(options)
-  M.options = vim.tbl_deep_extend("force", {}, M.options or defaults, options or {})
+  local base_options = M.options
+  if type(base_options) ~= "table" then
+    base_options = defaults
+  end
+  -- Ensure 'options' is a table before passing to vim.tbl_deep_extend
+  local opts_to_merge = {}
+  if type(options) == "table" then
+    opts_to_merge = options
+  end
+  M.options = vim.tbl_deep_extend("force", {}, base_options, opts_to_merge)
 end
-
-M.setup()
 
 return M

--- a/lua/eldritch/init.lua
+++ b/lua/eldritch/init.lua
@@ -4,12 +4,29 @@ local config = require("eldritch.config")
 
 local M = {}
 
----@param opts Config|nil
-function M.load(opts)
-  if opts then
-    require("eldritch.config").extend(opts)
+---@param arg string|table|nil
+function M.load(arg)
+  local opts_to_pass = {}
+  local current_colorscheme_name = vim.g.colors_name
+
+  if type(arg) == "table" then
+    -- If arg is a table, it's the full config options
+    opts_to_pass = arg
+  elseif type(arg) == "string" then
+    -- If arg is a string, it's a palette name
+    opts_to_pass.palette = arg
+  else
+    -- If arg is nil (i.e., eldritch colorscheme is loaded), use the palette from initial_options
+    opts_to_pass.palette = config.initial_options.palette or "default"
   end
+  -- If arg is nil, opts_to_pass remains empty, and config.extend will use defaults.
+
+  -- Always extend the configuration with a table
+  config.extend(opts_to_pass)
+
   util.load(theme.setup())
+
+  vim.g.colors_name = current_colorscheme_name
 end
 
 M.setup = config.setup

--- a/lua/eldritch/theme.lua
+++ b/lua/eldritch/theme.lua
@@ -22,6 +22,7 @@ function M.setup()
     config = options,
     colors = colors.setup(),
   }
+
   local is_transparent = theme.config.transparent
   local bg_float_configured = is_transparent and theme.colors.none or theme.colors.bg_float
 

--- a/lua/eldritch/util.lua
+++ b/lua/eldritch/util.lua
@@ -180,7 +180,6 @@ function M.load(theme)
   end
 
   vim.o.termguicolors = true
-  vim.g.colors_name = "eldritch"
 
   M.syntax(theme.highlights)
 


### PR DESCRIPTION
# Improve Eldritch Colorscheme Variant Switching

This PR addresses issues related to switching between the 'eldritch' and 'eldritch-dark' colorscheme variants, ensuring a smoother user experience and maintaining backward compatibility for existing configurations.

## Key Changes

### 🎨 Dedicated Colorscheme Files
Introduced `colors/eldritch-dark.lua` to allow direct selection of the darker variant using `vim.cmd.colorscheme('eldritch-dark')`.

### ⚡ Enhanced `M.load` Functionality
The `eldritch.load()` function in `lua/eldritch/init.lua` now intelligently handles palette selection:
- When called with a string argument (e.g., `eldritch.load("darker")`), it explicitly loads the specified palette
- When called without arguments (e.g., via `vim.cmd.colorscheme('eldritch')`), it respects the `palette` option set in the user's `eldritch.setup({})` configuration for retrocompatibility

### 🏷️ Correct Colorscheme Naming
Ensured that `vim.g.colors_name` is correctly set and preserved, so the `:colo` command accurately reflects the active colorscheme ('eldritch' or 'eldritch-dark').

### ⚙️ Configuration Management
Introduced `M.initial_options` in `lua/eldritch/config.lua` to reliably store the user's initial `setup()` preferences, which is crucial for maintaining retrocompatibility with the deprecated `palette` option.

### 📚 Documentation Updates
**The `palette` option is now officially deprecated.** It has been marked as such in both `README.md` and `lua/eldritch/config.lua`, guiding users towards the new `vim.cmd.colorscheme` method for switching variants.

## Benefits

These changes provide a more robust and intuitive way to manage Eldritch colorscheme variants, allowing for:
- 🔄 Seamless on-the-fly switching between variants
- 🔒 Backward compatibility with existing user configurations
- 🎯 More intuitive colorscheme selection using standard Vim commands


## Pictures
### Darker Palette with Default Variant ( retrocompatibility, prio to palette)
<img width="1512" height="982" alt="darker palette default theme" src="https://github.com/user-attachments/assets/b422ae39-87ea-4d17-9cd6-202c22d0eac5" />

### Default Palette with Dark Variant (prio to new Darker Variant)
<img width="1512" height="982" alt="default palette dark theme" src="https://github.com/user-attachments/assets/d3e49014-6574-452a-8bc2-b4a19e146fe7" />

### No Palette, Default Variant ( new standard for installation)
<img width="1512" height="982" alt="default theme no palette" src="https://github.com/user-attachments/assets/6fa6d4be-c65d-4bcf-a98a-2b7dbd86ee2c" />

### Telescope colorscheme
<img width="1512" height="982" alt="Screenshot 2025-07-10 at 6 22 12 PM" src="https://github.com/user-attachments/assets/367644db-4715-481c-b341-7d9c5ac31c93" />

